### PR TITLE
Measure sysclock sysdir 0930

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -18,7 +18,7 @@
 
 #include <app/CASESessionManager.h>
 #include <lib/address_resolve/AddressResolve.h>
-#include <tracing/DurationTimer.h>
+#include <system/DurationTimer.h>
 
 namespace chip {
 

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -38,7 +38,8 @@ void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Cal
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 )
 {
-    chip::timing::TimespecTimer timer ( "CASESessionManager: FindOrEstablishSession" );
+    
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "CASESessionManager: FindOrEstablishSession" );
     timer.start();
 
     ChipLogDetail(CASESessionManager, "FindOrEstablishSession: PeerId = [%d:" ChipLogFormatX64 "]", peerId.GetFabricIndex(),

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -32,7 +32,7 @@
 #include <platform/PlatformManager.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 #include <tracing/macros.h>
-#include <tracing/DurationTimer.h>
+#include <system/DurationTimer.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -220,7 +220,7 @@ CHIP_ERROR Instance::Write(const ConcreteDataAttributePath & aPath, AttributeVal
 void Instance::OnNetworkingStatusChange(NetworkCommissioning::Status aCommissioningError, Optional<ByteSpan> aNetworkId,
                                         Optional<int32_t> aConnectStatus)
 {
-    chip::timing::TimespecTimer timer ( "NetworkCommissioning: OnNetworkingStatusChange ");
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "NetworkCommissioning: OnNetworkingStatusChange ");
     timer.start();
     if (aNetworkId.HasValue() && aNetworkId.Value().size() > kMaxNetworkIDLen)
     {
@@ -250,7 +250,7 @@ void Instance::OnNetworkingStatusChange(NetworkCommissioning::Status aCommission
 
 void Instance::HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetworks::DecodableType & req)
 {
-    chip::timing::TimespecTimer timer ( "NetworkCommissioning: HandleScanNetwork ");
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "NetworkCommissioning: HandleScanNetwork ");
     timer.start();
     MATTER_TRACE_SCOPE("HandleScanNetwork", "NetworkCommissioning");
     if (mFeatureFlags.Has(Feature::kWiFiNetworkInterface))
@@ -325,7 +325,7 @@ bool CheckFailSafeArmed(CommandHandlerInterface::HandlerContext & ctx)
 
 void Instance::HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands::AddOrUpdateWiFiNetwork::DecodableType & req)
 {
-    chip::timing::TimespecTimer timer ( "NetworkCommissioning: HandleAddOrUpdateWiFiNetwork ");
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "NetworkCommissioning: HandleAddOrUpdateWiFiNetwork ");
     timer.start();
 
     MATTER_TRACE_SCOPE("HandleAddOrUpdateWiFiNetwork", "NetworkCommissioning");
@@ -387,7 +387,7 @@ void Instance::HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands
 
 void Instance::HandleAddOrUpdateThreadNetwork(HandlerContext & ctx, const Commands::AddOrUpdateThreadNetwork::DecodableType & req)
 {
-    chip::timing::TimespecTimer timer ( "NetworkCommissioning: HandleAddOrUpdateThreadNetwork ");
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "NetworkCommissioning: HandleAddOrUpdateThreadNetwork ");
     timer.start();
     MATTER_TRACE_SCOPE("HandleAddOrUpdateThreadNetwork", "NetworkCommissioning");
 
@@ -427,7 +427,7 @@ void Instance::CommitSavedBreadcrumb()
 
 void Instance::HandleRemoveNetwork(HandlerContext & ctx, const Commands::RemoveNetwork::DecodableType & req)
 {
-    chip::timing::TimespecTimer timer ( "NetworkCommissioning: HandleRemoveNetwork ");
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "NetworkCommissioning: HandleRemoveNetwork ");
     timer.start();
 
     MATTER_TRACE_SCOPE("HandleRemoveNetwork", "NetworkCommissioning");
@@ -454,7 +454,7 @@ void Instance::HandleRemoveNetwork(HandlerContext & ctx, const Commands::RemoveN
 
 void Instance::HandleConnectNetwork(HandlerContext & ctx, const Commands::ConnectNetwork::DecodableType & req)
 {
-    chip::timing::TimespecTimer timer ( "NetworkCommissioning: HandleConnectNetwork ");
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "NetworkCommissioning: HandleConnectNetwork ");
     timer.start();
 
     MATTER_TRACE_SCOPE("HandleConnectNetwork", "NetworkCommissioning");
@@ -477,7 +477,7 @@ void Instance::HandleConnectNetwork(HandlerContext & ctx, const Commands::Connec
 
 void Instance::HandleReorderNetwork(HandlerContext & ctx, const Commands::ReorderNetwork::DecodableType & req)
 {
-    chip::timing::TimespecTimer timer ( "NetworkCommissioning: HandleReorderNetwork ");
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "NetworkCommissioning: HandleReorderNetwork ");
     timer.start();
 
     MATTER_TRACE_SCOPE("HandleReorderNetwork", "NetworkCommissioning");

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -49,7 +49,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <string.h>
 #include <tracing/macros.h>
-#include <tracing/DurationTimer.h>
+#include <system/DurationTimer.h>
 
 using namespace chip;
 using namespace ::chip::Transport;

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -414,7 +414,7 @@ bool emberAfOperationalCredentialsClusterRemoveFabricCallback(app::CommandHandle
     ChipLogProgress(Zcl, "OpCreds: Received a RemoveFabric Command for FabricIndex 0x%x",
                     static_cast<unsigned>(fabricBeingRemoved));
 
-    chip::timing::TimespecTimer timer ( "OpCreds: RemoveFabric" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: RemoveFabric" );
     timer.start();
 
     if (!IsValidFabricIndex(fabricBeingRemoved))
@@ -482,7 +482,7 @@ bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(app::CommandH
 
     ChipLogProgress(Zcl, "OpCreds: Received an UpdateFabricLabel command");
 
-    chip::timing::TimespecTimer timer ( "OpCreds: UpdateFabricLabel" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: UpdateFabricLabel" );
     timer.start();
 
     if (label.size() > 32)
@@ -629,7 +629,7 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
 
     ChipLogProgress(Zcl, "OpCreds: Received an AddNOC command");
 
-    chip::timing::TimespecTimer timer ( "OpCreds: AddNOC" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: AddNOC" );
     timer.start();
 
     VerifyOrExit(NOCValue.size() <= Credentials::kMaxCHIPCertLength, nonDefaultStatus = Status::InvalidCommand);
@@ -793,7 +793,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
 
     ChipLogProgress(Zcl, "OpCreds: Received an UpdateNOC command");
 
-    chip::timing::TimespecTimer timer ( "OpCreds: UpdateNOC" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: UpdateNOC" );
     timer.start();
 
     auto & fabricTable            = Server::GetInstance().GetFabricTable();
@@ -879,7 +879,7 @@ bool emberAfOperationalCredentialsClusterCertificateChainRequestCallback(
     const Commands::CertificateChainRequest::DecodableType & commandData)
 {
 
-    chip::timing::TimespecTimer timer ( "OpCreds: Certificate Chain" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: Certificate Chain" );
     timer.start();
 
     MATTER_TRACE_SCOPE("CertificateChainRequest", "OperationalCredentials");
@@ -933,7 +933,7 @@ bool emberAfOperationalCredentialsClusterAttestationRequestCallback(app::Command
                                                                     const Commands::AttestationRequest::DecodableType & commandData)
 {
 
-    chip::timing::TimespecTimer timer ( "OpCreds: AttestationRequest" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: AttestationRequest" );
     timer.start();
 
     MATTER_TRACE_SCOPE("AttestationRequest", "OperationalCredentials");
@@ -1035,7 +1035,7 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
                                                             const Commands::CSRRequest::DecodableType & commandData)
 {
 
-    chip::timing::TimespecTimer timer ( "OpCreds: CSRRequest" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: CSRRequest" );
     timer.start();
 
     MATTER_TRACE_SCOPE("CSRRequest", "OperationalCredentials");
@@ -1176,7 +1176,7 @@ bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(
     const Commands::AddTrustedRootCertificate::DecodableType & commandData)
 {
 
-    chip::timing::TimespecTimer timer ( "OpCreds: AddTrustedRootCertificate" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "OpCreds: AddTrustedRootCertificate" );
     timer.start();
 
     MATTER_TRACE_SCOPE("AddTrustedRootCertificate", "OperationalCredentials");

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -234,7 +234,7 @@ CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow(Seconds16 commiss
 
 CHIP_ERROR CommissioningWindowManager::AdvertiseAndListenForPASE()
 {
-    chip::timing::TimespecTimer timer ( "AppServer: AdvertiseAndListenForPASE" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "AppServer: AdvertiseAndListenForPASE" );
     timer.start();
 
     VerifyOrReturnError(mCommissioningTimeoutTimerArmed, CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -24,7 +24,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DeviceControlServer.h>
-#include <tracing/DurationTimer.h>
+#include <system/DurationTimer.h>
 
 using namespace chip::app::Clusters;
 using namespace chip::System::Clock;

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -39,7 +39,7 @@
 #include <system/TimeSource.h>
 
 #include <app/server/Server.h>
-#include <tracing/DurationTimer.h>
+#include <system/DurationTimer.h>
 
 namespace chip {
 namespace app {

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -380,7 +380,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 {
     ChipLogProgress(Discovery, "Updating services using commissioning mode %d", static_cast<int>(mode));
     
-    chip::timing::TimespecTimer timer ( "Discover: StartServer " );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "Discover: StartServer " );
     timer.start();
 
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, 0);

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -22,7 +22,7 @@
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <transport/SessionManager.h>
-#include <tracing/DurationTimer.h>
+#include <system/DurationTimer.h>
 
 using namespace ::chip::Inet;
 using namespace ::chip::Transport;

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -124,7 +124,7 @@ exit:
 
 void CASEServer::PrepareForSessionEstablishment(const ScopedNodeId & previouslyEstablishedPeer)
 {
-    chip::timing::TimespecTimer timer ( "Inet: CASE Session establishment" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "Inet: CASE Session establishment" );
     timer.start();
 
     GetSession().Clear();

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -35,7 +35,7 @@ CHIP_ERROR PairingSession::AllocateSecureSession(SessionManager & sessionManager
 
 CHIP_ERROR PairingSession::ActivateSecureSession(const Transport::PeerAddress & peerAddress)
 {
-    chip::timing::TimespecTimer timer ( "Inet: ActivateSecureSession" );
+    chip::timing::DurationTimer timer = chip::timing::GetDefaultTimingInstance( "Inet: ActivateSecureSession" );
     timer.start();
 
     // Prepare SecureSession fields, including key derivation, first, before activation

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -20,7 +20,7 @@
 
 #include <lib/core/TLVTypes.h>
 #include <lib/support/SafeInt.h>
-#include <tracing/DurationTimer.h>
+#include <system/DurationTimer.h>
 
 namespace chip {
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -216,6 +216,8 @@ static_library("system") {
     "TimeSource.h",
     "WakeEvent.cpp",
     "WakeEvent.h",
+    "DurationTimer.h",
+    "DurationTimer.cpp",
   ]
 
   if (chip_system_layer_impl_config_file == "") {

--- a/src/system/DurationTimer.cpp
+++ b/src/system/DurationTimer.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <lib/support/logging/CHIPLogging.h>
 
-//#include <chrono>
+#include <chrono>
 //#include <ctime>
 //#include <iomanip>
 //#include <algorithm>
@@ -18,6 +18,9 @@ using namespace std::literals;
 //todo add description
 namespace chip{
     namespace timing{
+        #define DATETIME_PATTERN  ("%Y-%m-%dT%H:%M:%S")
+        #define DATETIME_LEN (sizeof "1970-01-01T23:59:59")
+        #define ISO8601_LEN (sizeof "1970-01-01T23:59:59.123456Z")
         /**   TimespecTimer implementations   */
 
         // member functions
@@ -26,9 +29,9 @@ namespace chip{
             chip::System::Clock::Timestamp tv1 = chip::System::SystemClock().GetMonotonicTimestamp();
 
             chip::System::Clock::ToTimeval(tv1, t1 );
-            // todo use logging instead of stdout
 
-            ChipLogDetail(DeviceLayer, "Timer: %s start %ld", label, t1.tv_usec);
+            //ChipLogDetail(DeviceLayer, "Timer: %s start %ld", label.c_str(), t1.tv_usec);
+            ChipLogDetail(DeviceLayer, "Timer: %s start time: %s ", label.c_str(), toTimeStr(&t1).c_str());
             //ChipLogDetail(DeviceLayer, "Timer: start %ld", t1.tv_usec);
         }
 
@@ -38,40 +41,41 @@ namespace chip{
             chip::System::Clock::Timestamp tv2 = chip::System::SystemClock().GetMonotonicTimestamp();
 
             chip::System::Clock::ToTimeval(tv2, t2 );
-            //ChipLogDetail(DeviceLayer, "Timer: %s stop %ld, ts: %s ", label, t2.tv_usec,TimespecTimer::toTimeStr(t2));
-            ChipLogDetail(DeviceLayer, "Timer: %s stop %ld ", label, t2.tv_usec);
-            //ChipLogDetail(DeviceLayer, "Timer: stop %ld, ts: %s ", t2.tv_usec,TimespecTimer::toTimeStr(t2));
+
+            //std::chrono::hh_mm_ss hms { tv2 }
+            //string tfs = std::format("{:%T}", tv2);
+            //ChipLogDetail(DeviceLayer, "Timer: %s stop %s ", label.c_str(), tfs);
+
+            ChipLogDetail(DeviceLayer, "Timer: %s stop time: %s ", label.c_str(), toTimeStr(&t2).c_str());
+            //ChipLogDetail(DeviceLayer, "Timer: %s stop %lld - %ld ", label.c_str(), t2.tv_sec, t2.tv_usec);
             duration();
 
-            //TimespecTimer::~TimespecTimer();
+        
         }
 
         double TimespecTimer::duration()
         {
             double dur =  ((t2.tv_usec - t1.tv_usec) * 1e-6);
 
-            chip::System::Clock::Seconds32 ts;
-            //ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f , ts: %s ", label, dur, TimespecTimer::toTimeStr(t2) );
-            ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f ", label, dur );
-            //ChipLogDetail(DeviceLayer, "Timer: TIME_SPENT (sec) %f , ts: %s ", dur, TimespecTimer::toTimeStr(t2) );
+            string timestr = toTimeStr(&t2);
+            ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f , time: %s ", label.c_str(), dur, timestr.c_str() );
+
             return dur;
         }
 
-        #define DATETIME_PATTERN  ("%Y-%m-%dT%H:%M:%SZ")
-        #define DATETIME_LEN (sizeof "1970-01-01T23:59:59.")
-        #define ISO8601_LEN (sizeof "1970-01-01T23:59:59.123456Z")
-
         // utility method
-        char * TimespecTimer::toTimeStr(timeval time)
+        string TimespecTimer::toTimeStr(timeval* time)
         {
-            char buff[DATETIME_LEN];
-            strftime(buff, sizeof buff, DATETIME_PATTERN, gmtime(&time.tv_sec));
-            char * str = new char[sizeof buff + 1];
-            snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time.tv_usec);
-            return str; // timeval_to_str( buff, 0, &time);
+            char * buff = new char[DATETIME_LEN];
+            //struct tm* tm_info = localtime(&(time->tv_sec));
+            struct tm* tm_info = gmtime(&(time->tv_sec));
+            strftime(buff, DATETIME_LEN, DATETIME_PATTERN, tm_info);
+            //string str(buff, DATETIME_LEN );
+            char * str = new char[ISO8601_LEN];
+            snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time->tv_usec);
+            
+            return str; 
         }
-
-        
 
     }
 }

--- a/src/system/DurationTimer.cpp
+++ b/src/system/DurationTimer.cpp
@@ -1,14 +1,13 @@
 #include "DurationTimer.h"
 #include <stdint.h>
-//#include <time.h>
-//#include <sys/time.h>
 #include <string>
 #include <lib/support/logging/CHIPLogging.h>
 
-#include <chrono>
-#include <ctime>
-#include <iomanip>
-#include <algorithm>
+//#include <chrono>
+//#include <ctime>
+//#include <iomanip>
+//#include <algorithm>
+//#include <sys/time.h>
 
 #include <system/SystemClock.h>
 
@@ -24,30 +23,59 @@ namespace chip{
         // member functions
         void TimespecTimer::start()
         {
-             t1 = chip::System::SystemClock().GetMonotonicTimestamp();
-           
+            chip::System::Clock::Timestamp tv1 = chip::System::SystemClock().GetMonotonicTimestamp();
+            
+            // gettimeofday(&tv1, NULL);
+            chip::System::Clock::ToTimeval(tv1, t1 );
             // todo use logging instead of stdout
             //const std::time_t t_c = std::chrono::system_clock::to_time_t(t1);
-            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
+            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&tv1), "%F %T.\n") << std::flush;
+            ChipLogDetail(DeviceLayer, "Timer: %s start %ld", label, t1.tv_usec);
         }
 
         void TimespecTimer::stop()
         {
         
-            t2 = chip::System::SystemClock().GetMonotonicTimestamp();
-
+            chip::System::Clock::Timestamp tv2 = chip::System::SystemClock().GetMonotonicTimestamp();
+            //timeval tv2;
+            // gettimeofday(&tv2, NULL);
+            chip::System::Clock::ToTimeval(tv2, t2 );
+            //chip::System::Clock::Seconds32 ts = System::Clock::Seconds32(seconds);
             //const std::time_t t_c = std::chrono::system_clock::to_time_t(t2);
-            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
+            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&tv2), "%F %T.\n") << std::flush;
+            ChipLogDetail(DeviceLayer, "Timer: %s stop %ld, ts: %s ", label, t2.tv_usec,TimespecTimer::toTimeStr(t2));
             duration();
 
             TimespecTimer::~TimespecTimer();
         }
 
-        long long int TimespecTimer::duration()
+        double TimespecTimer::duration()
         {
-            long long int dur = (t2.count() - t1.count());
-            cout << "Timer " << *label << " TIME_SPENT (msec) " << dur << '\n';
+            //long long int dur = (t2.count() - t1.count());
+            //cout << "Timer " << *label << " TIME_SPENT (msec) " << dur << '\n';
+            //return dur;
+            //return ((t2.tv_sec - t1.tv_sec) + ((t2.tv_usec - t1.tv_usec) * 1e-9));
+            double dur =  ((t2.tv_usec - t1.tv_usec) * 1e-6);
+            //cout << "Timer " << *label << " TIME_SPENT (msec) " << dur << '\n';
+            //ChipLogDetail(chipSystemLayer, "PacketBuffer: RightSize Copied");
+            //ChipLogDetail(DeviceLayer, "PacketBuffer: RightSize Copied");
+            chip::System::Clock::Seconds32 ts;
+            ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f , ts: %s ", label, dur, TimespecTimer::toTimeStr(t2) );
             return dur;
+        }
+
+        #define DATETIME_PATTERN  ("%Y-%m-%dT%H:%M:%SZ")
+        #define DATETIME_LEN (sizeof "1970-01-01T23:59:59.")
+        #define ISO8601_LEN (sizeof "1970-01-01T23:59:59.123456Z")
+
+        // utility method
+        char * TimespecTimer::toTimeStr(timeval time)
+        {
+            char buff[DATETIME_LEN];
+            strftime(buff, sizeof buff, DATETIME_PATTERN, gmtime(&time.tv_sec));
+            char * str = new char[sizeof buff + 1];
+            snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time.tv_usec);
+            return str; // timeval_to_str( buff, 0, &time);
         }
 
         

--- a/src/system/DurationTimer.cpp
+++ b/src/system/DurationTimer.cpp
@@ -10,6 +10,8 @@
 #include <iomanip>
 #include <algorithm>
 
+#include <system/SystemClock.h>
+
 
 using namespace std;
 using namespace std::literals;
@@ -22,29 +24,28 @@ namespace chip{
         // member functions
         void TimespecTimer::start()
         {
-            //System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
-             t1 = std::chrono::system_clock::now();
+             t1 = chip::System::SystemClock().GetMonotonicTimestamp();
            
             // todo use logging instead of stdout
-            const std::time_t t_c = std::chrono::system_clock::to_time_t(t1);
-            cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
+            //const std::time_t t_c = std::chrono::system_clock::to_time_t(t1);
+            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
         }
 
         void TimespecTimer::stop()
         {
         
-            t2 = std::chrono::system_clock::now();
+            t2 = chip::System::SystemClock().GetMonotonicTimestamp();
 
-            const std::time_t t_c = std::chrono::system_clock::to_time_t(t2);
-            cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
+            //const std::time_t t_c = std::chrono::system_clock::to_time_t(t2);
+            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
             duration();
 
             TimespecTimer::~TimespecTimer();
         }
 
-        double TimespecTimer::duration()
+        long long int TimespecTimer::duration()
         {
-            double dur = (t2 - t1) / 1ms;
+            long long int dur = (t2.count() - t1.count());
             cout << "Timer " << *label << " TIME_SPENT (msec) " << dur << '\n';
             return dur;
         }

--- a/src/system/DurationTimer.cpp
+++ b/src/system/DurationTimer.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <lib/support/logging/CHIPLogging.h>
 
-#ifdef CHIP_DEVICE_IS_NRF
+#if defined  (CHIP_DEVICE_IS_NRF)  
 #include <system/SystemClock.h>
 #endif
 
@@ -17,8 +17,11 @@ using namespace std::literals;
 //todo add description
 namespace chip{
     namespace timing{
+
         #define DATETIME_PATTERN  ("%Y-%m-%dT%H:%M:%S")
+        
         #define DATETIME_LEN (sizeof "1970-01-01T23:59:59")
+        
         #define ISO8601_LEN (sizeof "1970-01-01T23:59:59.123456Z")
         
         #ifdef CHIP_DEVICE_IS_NRF
@@ -41,9 +44,7 @@ namespace chip{
 
             chip::System::Clock::ToTimeval(tv1, t1 );
 
-            //ChipLogDetail(DeviceLayer, "Timer: %s start %ld", label.c_str(), t1.tv_usec);
             ChipLogDetail(DeviceLayer, "Timer: %s start time: %s ", label.c_str(), toTimeStr(&t1).c_str());
-            //ChipLogDetail(DeviceLayer, "Timer: start %ld", t1.tv_usec);
         }
 
         void DurationTimer::stop()
@@ -53,15 +54,9 @@ namespace chip{
 
             chip::System::Clock::ToTimeval(tv2, t2 );
 
-            //std::chrono::hh_mm_ss hms { tv2 }
-            //string tfs = std::format("{:%T}", tv2);
-            //ChipLogDetail(DeviceLayer, "Timer: %s stop %s ", label.c_str(), tfs);
-
             ChipLogDetail(DeviceLayer, "Timer: %s stop time: %s ", label.c_str(), toTimeStr(&t2).c_str());
-            //ChipLogDetail(DeviceLayer, "Timer: %s stop %lld - %ld ", label.c_str(), t2.tv_sec, t2.tv_usec);
+            
             duration();
-
-        
         }
 
         double DurationTimer::duration()
@@ -69,6 +64,7 @@ namespace chip{
             double dur =  ((t2.tv_usec - t1.tv_usec) * 1e-6);
 
             string timestr = toTimeStr(&t2);
+
             ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f , time: %s ", label.c_str(), dur, timestr.c_str() );
 
             return dur;
@@ -78,10 +74,9 @@ namespace chip{
         string DurationTimer::toTimeStr(timeval* time)
         {
             char * buff = new char[DATETIME_LEN];
-            //struct tm* tm_info = localtime(&(time->tv_sec));
+
             struct tm* tm_info = gmtime(&(time->tv_sec));
             strftime(buff, DATETIME_LEN, DATETIME_PATTERN, tm_info);
-            //string str(buff, DATETIME_LEN );
             char * str = new char[ISO8601_LEN];
             snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time->tv_usec);
             
@@ -94,13 +89,16 @@ namespace chip{
         void DurationTimer::start()
         {
             clock_gettime(CLOCK_REALTIME, &t1);
+
             ChipLogDetail(DeviceLayer, "Timer: %s start time: %s ", label.c_str(), toTimeStr(&t1).c_str());
         }
 
         void DurationTimer::stop()
         {
             clock_gettime(CLOCK_REALTIME, &t2);
+
             ChipLogDetail(DeviceLayer, "Timer: %s stop time: %s ", label.c_str(), toTimeStr(&t2).c_str());
+            
             duration();
         }
 
@@ -109,6 +107,7 @@ namespace chip{
             double dur = (double)(t2.tv_sec - t1.tv_sec) + ((t2.tv_nsec - t1.tv_nsec) * 1e-6);
 
             string timestr = toTimeStr(&t2);
+
             ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f , time: %s ", label.c_str(), dur, timestr.c_str() );
 
             return dur;
@@ -118,11 +117,13 @@ namespace chip{
         string DurationTimer::toTimeStr(timespec* time)
         {
             char * buff = new char[DATETIME_LEN];
-            //struct tm* tm_info = localtime(&(time->tv_sec));
+
             struct tm* tm_info = gmtime(&(time->tv_sec));
+
             strftime(buff, DATETIME_LEN, DATETIME_PATTERN, tm_info);
-            //string str(buff, DATETIME_LEN );
+
             char * str = new char[ISO8601_LEN];
+
             snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time->tv_nsec);
             
             return str; 

--- a/src/system/DurationTimer.cpp
+++ b/src/system/DurationTimer.cpp
@@ -24,43 +24,36 @@ namespace chip{
         void TimespecTimer::start()
         {
             chip::System::Clock::Timestamp tv1 = chip::System::SystemClock().GetMonotonicTimestamp();
-            
-            // gettimeofday(&tv1, NULL);
+
             chip::System::Clock::ToTimeval(tv1, t1 );
             // todo use logging instead of stdout
-            //const std::time_t t_c = std::chrono::system_clock::to_time_t(t1);
-            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&tv1), "%F %T.\n") << std::flush;
+
             ChipLogDetail(DeviceLayer, "Timer: %s start %ld", label, t1.tv_usec);
+            //ChipLogDetail(DeviceLayer, "Timer: start %ld", t1.tv_usec);
         }
 
         void TimespecTimer::stop()
         {
         
             chip::System::Clock::Timestamp tv2 = chip::System::SystemClock().GetMonotonicTimestamp();
-            //timeval tv2;
-            // gettimeofday(&tv2, NULL);
+
             chip::System::Clock::ToTimeval(tv2, t2 );
-            //chip::System::Clock::Seconds32 ts = System::Clock::Seconds32(seconds);
-            //const std::time_t t_c = std::chrono::system_clock::to_time_t(t2);
-            //cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&tv2), "%F %T.\n") << std::flush;
-            ChipLogDetail(DeviceLayer, "Timer: %s stop %ld, ts: %s ", label, t2.tv_usec,TimespecTimer::toTimeStr(t2));
+            //ChipLogDetail(DeviceLayer, "Timer: %s stop %ld, ts: %s ", label, t2.tv_usec,TimespecTimer::toTimeStr(t2));
+            ChipLogDetail(DeviceLayer, "Timer: %s stop %ld ", label, t2.tv_usec);
+            //ChipLogDetail(DeviceLayer, "Timer: stop %ld, ts: %s ", t2.tv_usec,TimespecTimer::toTimeStr(t2));
             duration();
 
-            TimespecTimer::~TimespecTimer();
+            //TimespecTimer::~TimespecTimer();
         }
 
         double TimespecTimer::duration()
         {
-            //long long int dur = (t2.count() - t1.count());
-            //cout << "Timer " << *label << " TIME_SPENT (msec) " << dur << '\n';
-            //return dur;
-            //return ((t2.tv_sec - t1.tv_sec) + ((t2.tv_usec - t1.tv_usec) * 1e-9));
             double dur =  ((t2.tv_usec - t1.tv_usec) * 1e-6);
-            //cout << "Timer " << *label << " TIME_SPENT (msec) " << dur << '\n';
-            //ChipLogDetail(chipSystemLayer, "PacketBuffer: RightSize Copied");
-            //ChipLogDetail(DeviceLayer, "PacketBuffer: RightSize Copied");
+
             chip::System::Clock::Seconds32 ts;
-            ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f , ts: %s ", label, dur, TimespecTimer::toTimeStr(t2) );
+            //ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f , ts: %s ", label, dur, TimespecTimer::toTimeStr(t2) );
+            ChipLogDetail(DeviceLayer, "Timer: %s TIME_SPENT (sec) %f ", label, dur );
+            //ChipLogDetail(DeviceLayer, "Timer: TIME_SPENT (sec) %f , ts: %s ", dur, TimespecTimer::toTimeStr(t2) );
             return dur;
         }
 

--- a/src/system/DurationTimer.cpp
+++ b/src/system/DurationTimer.cpp
@@ -1,16 +1,9 @@
 #include "DurationTimer.h"
 #include <stdint.h>
 #include <string>
+//#include <chrono>
 #include <lib/support/logging/CHIPLogging.h>
-
-#include <chrono>
-//#include <ctime>
-//#include <iomanip>
-//#include <algorithm>
-//#include <sys/time.h>
-
 #include <system/SystemClock.h>
-
 
 using namespace std;
 using namespace std::literals;
@@ -21,10 +14,21 @@ namespace chip{
         #define DATETIME_PATTERN  ("%Y-%m-%dT%H:%M:%S")
         #define DATETIME_LEN (sizeof "1970-01-01T23:59:59")
         #define ISO8601_LEN (sizeof "1970-01-01T23:59:59.123456Z")
-        /**   TimespecTimer implementations   */
+        
+        /*const FabricTable * fabricTable;
+        System::Clock::Seconds32 lastKnownGoodChipEpochTime;
+        err = mFabricsTable->GetLastKnownGoodChipEpochTime(lastKnownGoodChipEpochTime);
+        if (err != CHIP_NO_ERROR)
+        {
+            // If we have no time available, the Validity Policy will
+            // determine what to do.
+            ChipLogError(DeviceLayer, "Failed to retrieve Last Known Good UTC Time");
+        }*/
+        
+        /**   DurationTimer implementations   */
 
         // member functions
-        void TimespecTimer::start()
+        void DurationTimer::start()
         {
             chip::System::Clock::Timestamp tv1 = chip::System::SystemClock().GetMonotonicTimestamp();
 
@@ -35,7 +39,7 @@ namespace chip{
             //ChipLogDetail(DeviceLayer, "Timer: start %ld", t1.tv_usec);
         }
 
-        void TimespecTimer::stop()
+        void DurationTimer::stop()
         {
         
             chip::System::Clock::Timestamp tv2 = chip::System::SystemClock().GetMonotonicTimestamp();
@@ -53,7 +57,7 @@ namespace chip{
         
         }
 
-        double TimespecTimer::duration()
+        double DurationTimer::duration()
         {
             double dur =  ((t2.tv_usec - t1.tv_usec) * 1e-6);
 
@@ -64,7 +68,7 @@ namespace chip{
         }
 
         // utility method
-        string TimespecTimer::toTimeStr(timeval* time)
+        string DurationTimer::toTimeStr(timeval* time)
         {
             char * buff = new char[DATETIME_LEN];
             //struct tm* tm_info = localtime(&(time->tv_sec));
@@ -75,6 +79,16 @@ namespace chip{
             snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time->tv_usec);
             
             return str; 
+        }
+
+        DurationTimer GetDefaultTimingInstance(string label)
+        {
+            return chip::timing::DurationTimer(label);      
+        }
+
+        DurationTimer * GetDefaultTimingInstancePtr(string label)
+        {
+            return new chip::timing::DurationTimer(label);            
         }
 
     }

--- a/src/system/DurationTimer.h
+++ b/src/system/DurationTimer.h
@@ -1,24 +1,16 @@
 #pragma once
 
 #include <string>
-//#include <time.h>
-//#include <sys/time.h>
-//#include <iostream>
-//#include <stdio.h>
-//#include <chrono>
-//#include <ctime>
 #include <system/SystemClock.h>
 
 using namespace std;
-
-//using namespace chip::System;
 
 //todo add description
 namespace chip{
     namespace timing{
         
         //todo add description
-        class TimespecTimer {
+        class DurationTimer {
                 
                 private:
                     string toTimeStr(timeval* time);
@@ -29,18 +21,19 @@ namespace chip{
                 public:
                     //constructors
                     //TimespecTimer(uint8_t mod, string s ):  DurationTimer(mod, s){};
-                    TimespecTimer( string s ){
+                    DurationTimer( string s ){
                         label =  s;
                     }
-                    ~TimespecTimer()=default;
+                    ~DurationTimer()=default;
                     //member functions
                     void start();
                     void stop();
                     double duration(); 
-                    //string toTimeStr(timeval* time);
-                    //void toDateTime(char* timestr, timeval* time);
 
         };
+
+        DurationTimer GetDefaultTimingInstance(string label);
+        DurationTimer * GetDefaultTimingInstancePtr(string label);
 
     }
 }

--- a/src/system/DurationTimer.h
+++ b/src/system/DurationTimer.h
@@ -1,7 +1,27 @@
 #pragma once
 
 #include <string>
-#include <system/SystemClock.h>
+
+/**
+ * CHIP_DEVICE_IS_ESP32
+ *
+ * If 1, enable then assume esp32 device.
+ */
+#ifndef CHIP_DEVICE_IS_ESP32
+#define CHIP_DEVICE_IS_ESP32 1
+#endif
+
+
+/**
+ * CHIP_DEVICE_IS_NRF
+ *
+ * If 1, enable then assume nRF device.
+ 
+
+#ifndef CHIP_DEVICE_IS_NRF
+#define CHIP_DEVICE_IS_NRF 1
+#endif
+*/
 
 using namespace std;
 
@@ -11,13 +31,24 @@ namespace chip{
         
         //todo add description
         class DurationTimer {
-                
+                #ifdef CHIP_DEVICE_IS_NRF
                 private:
                     string toTimeStr(timeval* time);
                 protected:
                     timeval t1;
                     timeval t2;
                     string label;
+                #endif
+
+                #ifdef CHIP_DEVICE_IS_ESP32
+                private:
+                    string toTimeStr(timespec* time);
+                protected:
+                    timespec t1;
+                    timespec t2;
+                    string label;
+                #endif    
+
                 public:
                     //constructors
                     //TimespecTimer(uint8_t mod, string s ):  DurationTimer(mod, s){};

--- a/src/system/DurationTimer.h
+++ b/src/system/DurationTimer.h
@@ -6,22 +6,29 @@
  * CHIP_DEVICE_IS_ESP32
  *
  * If 1, enable then assume esp32 device.
- */
-#ifndef CHIP_DEVICE_IS_ESP32
-#define CHIP_DEVICE_IS_ESP32 1
-#endif
-
-
+*/
+//#ifndef CHIP_DEVICE_IS_ESP32
+//#define CHIP_DEVICE_IS_ESP32 1
+//#endif
+ 
 /**
  * CHIP_DEVICE_IS_NRF
  *
  * If 1, enable then assume nRF device.
- 
+*/ 
 
 #ifndef CHIP_DEVICE_IS_NRF
 #define CHIP_DEVICE_IS_NRF 1
+#undef CHIP_DEVICE_IS_ESP32
 #endif
-*/
+
+#if defined  (CHIP_DEVICE_IS_NRF)  
+#include <system/SystemClock.h>
+#endif
+
+#if defined  (CHIP_DEVICE_IS_ESP32) || defined (CHIP_DEVICE_IS_ESP32_2)
+#include <time.h>
+#endif
 
 using namespace std;
 
@@ -51,7 +58,6 @@ namespace chip{
 
                 public:
                     //constructors
-                    //TimespecTimer(uint8_t mod, string s ):  DurationTimer(mod, s){};
                     DurationTimer( string s ){
                         label =  s;
                     }

--- a/src/system/DurationTimer.h
+++ b/src/system/DurationTimer.h
@@ -25,7 +25,7 @@ namespace chip{
                 protected:
                     timeval t1;
                     timeval t2;
-                    const char * label;
+                    char * label;
                     //string s;
                 public:
                     //constructors
@@ -35,16 +35,17 @@ namespace chip{
                         label =  s.data();
                         //label =  s;
                     }
-                    ~TimespecTimer(){
+                    /*~TimespecTimer(){
                         delete label;
                         //t1=1;
                         //t2=1;
-                    }
+                    }*/
+                    ~TimespecTimer()=default;
                     //member functions
                     void start();
                     void stop();
                     double duration(); 
-                    char * toTimeStr(timeval time);
+                    static char * toTimeStr(timeval time);
 
         };
 

--- a/src/system/DurationTimer.h
+++ b/src/system/DurationTimer.h
@@ -21,31 +21,24 @@ namespace chip{
         class TimespecTimer {
                 
                 private:
-                    //char* toTimeStr(std::chrono::time_point time);
+                    string toTimeStr(timeval* time);
                 protected:
                     timeval t1;
                     timeval t2;
-                    char * label;
-                    //string s;
+                    string label;
                 public:
                     //constructors
                     //TimespecTimer(uint8_t mod, string s ):  DurationTimer(mod, s){};
                     TimespecTimer( string s ){
-                        //label =  s.c_str();
-                        label =  s.data();
-                        //label =  s;
+                        label =  s;
                     }
-                    /*~TimespecTimer(){
-                        delete label;
-                        //t1=1;
-                        //t2=1;
-                    }*/
                     ~TimespecTimer()=default;
                     //member functions
                     void start();
                     void stop();
                     double duration(); 
-                    static char * toTimeStr(timeval time);
+                    //string toTimeStr(timeval* time);
+                    //void toDateTime(char* timestr, timeval* time);
 
         };
 

--- a/src/system/DurationTimer.h
+++ b/src/system/DurationTimer.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <chrono>
 #include <ctime>
+#include <system/SystemClock.h>
 
 using namespace std;
 
@@ -22,8 +23,8 @@ namespace chip{
                 private:
                     //char* toTimeStr(std::chrono::time_point time);
                 protected:
-                    std::chrono::time_point<std::chrono::system_clock> t1;
-                    std::chrono::time_point<std::chrono::system_clock> t2;
+                    chip::System::Clock::Timestamp t1;
+                    chip::System::Clock::Timestamp t2;
                     string * label;
                 public:
                     //constructors
@@ -33,13 +34,13 @@ namespace chip{
                     }
                     ~TimespecTimer(){
                         delete label;
-                        //t1=0;
-                        //t2=0;
+                        t1=1;
+                        t2=1;
                     }
                     //member functions
                     void start();
                     void stop();
-                    double duration(); 
+                    long long int duration(); 
 
         };
 

--- a/src/system/DurationTimer.h
+++ b/src/system/DurationTimer.h
@@ -3,10 +3,10 @@
 #include <string>
 //#include <time.h>
 //#include <sys/time.h>
-#include <iostream>
-#include <stdio.h>
-#include <chrono>
-#include <ctime>
+//#include <iostream>
+//#include <stdio.h>
+//#include <chrono>
+//#include <ctime>
 #include <system/SystemClock.h>
 
 using namespace std;
@@ -23,24 +23,28 @@ namespace chip{
                 private:
                     //char* toTimeStr(std::chrono::time_point time);
                 protected:
-                    chip::System::Clock::Timestamp t1;
-                    chip::System::Clock::Timestamp t2;
-                    string * label;
+                    timeval t1;
+                    timeval t2;
+                    const char * label;
+                    //string s;
                 public:
                     //constructors
                     //TimespecTimer(uint8_t mod, string s ):  DurationTimer(mod, s){};
                     TimespecTimer( string s ){
-                        label = &s;
+                        //label =  s.c_str();
+                        label =  s.data();
+                        //label =  s;
                     }
                     ~TimespecTimer(){
                         delete label;
-                        t1=1;
-                        t2=1;
+                        //t1=1;
+                        //t2=1;
                     }
                     //member functions
                     void start();
                     void stop();
-                    long long int duration(); 
+                    double duration(); 
+                    char * toTimeStr(timeval time);
 
         };
 

--- a/src/tracing/BUILD.gn
+++ b/src/tracing/BUILD.gn
@@ -38,8 +38,6 @@ static_library("tracing") {
     "log_declares.h",
     "registry.cpp",
     "registry.h",
-    "DurationTimer.h",
-    "DurationTimer.cpp",
   ]
 
   public_deps = [

--- a/src/tracing/DurationTimer.cpp
+++ b/src/tracing/DurationTimer.cpp
@@ -4,49 +4,52 @@
 //#include <sys/time.h>
 #include <string>
 #include <lib/support/logging/CHIPLogging.h>
-//#include <system/SystemClock.h>
-//#include <src/system/SystemClock.h>
-//#include <platform/CHIPDeviceLayer.h>
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <algorithm>
+
 
 using namespace std;
-using namespace chip;
+using namespace std::literals;
+
 //todo add description
 namespace chip{
     namespace timing{
         /**   TimespecTimer implementations   */
 
-                //static function
-            double TimespecTimer::duration_calc(uint64_t start, uint64_t stop)
-        {
-            //return (stop.tv_sec - start.tv_sec) + ((stop.tv_usec - start.tv_usec) * 1e-9);
-            //start.
-            return (stop - start);
-        }
-
         // member functions
         void TimespecTimer::start()
         {
-            t1 = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
-
+            //System::Clock::Timestamp now = System::SystemClock().GetMonotonicTimestamp();
+             t1 = std::chrono::system_clock::now();
+           
             // todo use logging instead of stdout
-            cout << "Timer " << label << " start " << chip::System::SystemClock().GetClock_RealTimeMS(t1) << '\n';
+            const std::time_t t_c = std::chrono::system_clock::to_time_t(t1);
+            cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
         }
 
         void TimespecTimer::stop()
         {
-            t2 = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+        
+            t2 = std::chrono::system_clock::now();
 
-            cout << "Timer " << label << " stop " << chip::System::SystemClock().GetClock_RealTimeMS(t2) << '\n';
+            const std::time_t t_c = std::chrono::system_clock::to_time_t(t2);
+            cout << "Timer " << (*label) << " start " << std::put_time(std::localtime(&t_c), "%F %T.\n") << std::flush;
             duration();
+
+            TimespecTimer::~TimespecTimer();
         }
 
         double TimespecTimer::duration()
         {
-            double dur = duration_calc(t1, t2);
-            cout << "Timer " << label << " TIME_SPENT (sec) " << dur << '\n';
+            double dur = (t2 - t1) / 1ms;
+            cout << "Timer " << *label << " TIME_SPENT (msec) " << dur << '\n';
             return dur;
         }
 
+        
 
     }
 }

--- a/src/tracing/DurationTimer.cpp
+++ b/src/tracing/DurationTimer.cpp
@@ -1,41 +1,42 @@
 #include "DurationTimer.h"
 #include <stdint.h>
 //#include <time.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 #include <string>
 #include <lib/support/logging/CHIPLogging.h>
+//#include <system/SystemClock.h>
+//#include <src/system/SystemClock.h>
+//#include <platform/CHIPDeviceLayer.h>
 
 using namespace std;
-
+using namespace chip;
 //todo add description
 namespace chip{
     namespace timing{
         /**   TimespecTimer implementations   */
 
                 //static function
-            double TimespecTimer::duration_calc(timeval start, timeval stop)
+            double TimespecTimer::duration_calc(uint64_t start, uint64_t stop)
         {
-            return (stop.tv_sec - start.tv_sec) + ((stop.tv_usec - start.tv_usec) * 1e-9);
+            //return (stop.tv_sec - start.tv_sec) + ((stop.tv_usec - start.tv_usec) * 1e-9);
+            //start.
+            return (stop - start);
         }
 
         // member functions
         void TimespecTimer::start()
         {
-            struct timeval now;
-            gettimeofday(&now, NULL);
-            t1 = now;
+            t1 = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
 
             // todo use logging instead of stdout
-            cout << "Timer " << label << " start " << toTimeStr(now) << '\n';
+            cout << "Timer " << label << " start " << chip::System::SystemClock().GetClock_RealTimeMS(t1) << '\n';
         }
 
         void TimespecTimer::stop()
         {
-            struct timeval now;
-            gettimeofday(&now, NULL);
-            t2 = now;
+            t2 = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
 
-            cout << "Timer " << label << " stop " << toTimeStr(now) << '\n';
+            cout << "Timer " << label << " stop " << chip::System::SystemClock().GetClock_RealTimeMS(t2) << '\n';
             duration();
         }
 
@@ -46,19 +47,6 @@ namespace chip{
             return dur;
         }
 
-        #define DATETIME_PATTERN  ("%Y-%m-%dT%H:%M:%SZ")
-        #define DATETIME_LEN (sizeof "1970-01-01T23:59:59.")
-        #define ISO8601_LEN (sizeof "1970-01-01T23:59:59.123456Z")
-
-        // utility method
-        char * TimespecTimer::toTimeStr(timeval time)
-        {
-            char buff[DATETIME_LEN];
-            strftime(buff, sizeof buff, DATETIME_PATTERN, gmtime(&time.tv_sec));
-            char * str = new char[sizeof buff + 1];
-            snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time.tv_usec);
-            return str; // timeval_to_str( buff, 0, &time);
-        }
 
     }
 }

--- a/src/tracing/DurationTimer.cpp
+++ b/src/tracing/DurationTimer.cpp
@@ -1,6 +1,7 @@
 #include "DurationTimer.h"
 #include <stdint.h>
-#include <time.h>
+//#include <time.h>
+#include <sys/time.h>
 #include <string>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -11,42 +12,52 @@ namespace chip{
     namespace timing{
         /**   TimespecTimer implementations   */
 
-        //static function
-        double TimespecTimer::duration_calc(timespec start, timespec stop){
-            return (stop.tv_sec - start.tv_sec)+((stop.tv_nsec - start.tv_nsec) * 1e-9);
+                //static function
+            double TimespecTimer::duration_calc(timeval start, timeval stop)
+        {
+            return (stop.tv_sec - start.tv_sec) + ((stop.tv_usec - start.tv_usec) * 1e-9);
         }
 
-        //member functions
-        void TimespecTimer::start(){
-            struct timespec now;
-            clock_gettime(CLOCK_REALTIME, &now);
+        // member functions
+        void TimespecTimer::start()
+        {
+            struct timeval now;
+            gettimeofday(&now, NULL);
             t1 = now;
-            //todo use logging instead of stdout
-            cout <<  "Timer "<< label << " start " << toTimeStr( now ) << '\n';
+
+            // todo use logging instead of stdout
+            cout << "Timer " << label << " start " << toTimeStr(now) << '\n';
         }
 
-        void TimespecTimer::stop(){
-            struct timespec now;
-            clock_gettime(CLOCK_REALTIME, &now) ;
+        void TimespecTimer::stop()
+        {
+            struct timeval now;
+            gettimeofday(&now, NULL);
             t2 = now;
-            cout <<  "Timer "<< label << " stop " << toTimeStr( now ) << '\n';
+
+            cout << "Timer " << label << " stop " << toTimeStr(now) << '\n';
             duration();
         }
 
-        double TimespecTimer::duration(){
-            double dur = duration_calc(t1,t2);
-            cout <<  "Timer "<< label << " TIME_SPENT (sec) " << dur << '\n';
+        double TimespecTimer::duration()
+        {
+            double dur = duration_calc(t1, t2);
+            cout << "Timer " << label << " TIME_SPENT (sec) " << dur << '\n';
             return dur;
         }
 
-        //utility method
-        char* TimespecTimer::toTimeStr(timespec time){
-            char buff[100];
-            strftime(buff, sizeof buff, "%D %T", gmtime(&time.tv_sec) );
-            char* str = new char[ sizeof buff + 1];
-            //todo revisit this size
-            snprintf(str, sizeof(buff)+4+21 , " %s.%09ld", buff, time.tv_nsec );
-            return str;
+        #define DATETIME_PATTERN  ("%Y-%m-%dT%H:%M:%SZ")
+        #define DATETIME_LEN (sizeof "1970-01-01T23:59:59.")
+        #define ISO8601_LEN (sizeof "1970-01-01T23:59:59.123456Z")
+
+        // utility method
+        char * TimespecTimer::toTimeStr(timeval time)
+        {
+            char buff[DATETIME_LEN];
+            strftime(buff, sizeof buff, DATETIME_PATTERN, gmtime(&time.tv_sec));
+            char * str = new char[sizeof buff + 1];
+            snprintf(str, ISO8601_LEN, " %s.%05ld", buff, time.tv_usec);
+            return str; // timeval_to_str( buff, 0, &time);
         }
 
     }

--- a/src/tracing/DurationTimer.h
+++ b/src/tracing/DurationTimer.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <string>
-#include <time.h>
+//#include <time.h>
+#include <sys/time.h>
 #include <iostream>
 #include <stdio.h>
 
@@ -35,10 +36,10 @@ namespace chip{
         };
 
         //todo add description
-        class TimespecTimer : public DurationTimer<timespec>{
+        class TimespecTimer : public DurationTimer<timeval>{
                 
                 private:
-                    char* toTimeStr(timespec time);
+                    char* toTimeStr(timeval time);
 
                 public:
                     //constructors
@@ -50,7 +51,7 @@ namespace chip{
                     void stop();
                     double duration(); 
 
-                    double static duration_calc(timespec start, timespec stop) ;
+                    double static duration_calc(timeval start, timeval stop) ;
         };
 
     }

--- a/src/tracing/DurationTimer.h
+++ b/src/tracing/DurationTimer.h
@@ -5,55 +5,42 @@
 //#include <sys/time.h>
 #include <iostream>
 #include <stdio.h>
-#include <platform/CHIPDeviceLayer.h>
+#include <chrono>
+#include <ctime>
 
 using namespace std;
+
 //using namespace chip::System;
 
 //todo add description
 namespace chip{
     namespace timing{
         
-        template <typename T>
-        class DurationTimer{
-            protected:
-                T t1;
-                T t2;
-                string label;
-                //todo revisit module references
-                uint8_t module;
-            public:    
-                //constructors
-                DurationTimer(uint8_t mod, string s ){
-                   module = mod;
-                   label = s;
-                }
-                DurationTimer(string s ){
-                   label = s;
-                }
-                void start();
-                void stop();
-                double duration(); 
-                static double duration_calc(T start, T stop); 
-        };
-
         //todo add description
-        class TimespecTimer : public DurationTimer<uint64_t>{
+        class TimespecTimer {
                 
                 private:
-                    char* toTimeStr(uint64_t time);
-
+                    //char* toTimeStr(std::chrono::time_point time);
+                protected:
+                    std::chrono::time_point<std::chrono::system_clock> t1;
+                    std::chrono::time_point<std::chrono::system_clock> t2;
+                    string * label;
                 public:
                     //constructors
-                    TimespecTimer(uint8_t mod, string s ):  DurationTimer(mod, s){};
-                    TimespecTimer( string s ): DurationTimer(s){};
-
+                    //TimespecTimer(uint8_t mod, string s ):  DurationTimer(mod, s){};
+                    TimespecTimer( string s ){
+                        label = &s;
+                    }
+                    ~TimespecTimer(){
+                        delete label;
+                        //t1=0;
+                        //t2=0;
+                    }
                     //member functions
                     void start();
                     void stop();
                     double duration(); 
 
-                    double static duration_calc(uint64_t start, uint64_t stop) ;
         };
 
     }

--- a/src/tracing/DurationTimer.h
+++ b/src/tracing/DurationTimer.h
@@ -2,11 +2,13 @@
 
 #include <string>
 //#include <time.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 #include <iostream>
 #include <stdio.h>
+#include <platform/CHIPDeviceLayer.h>
 
 using namespace std;
+//using namespace chip::System;
 
 //todo add description
 namespace chip{
@@ -36,10 +38,10 @@ namespace chip{
         };
 
         //todo add description
-        class TimespecTimer : public DurationTimer<timeval>{
+        class TimespecTimer : public DurationTimer<uint64_t>{
                 
                 private:
-                    char* toTimeStr(timeval time);
+                    char* toTimeStr(uint64_t time);
 
                 public:
                     //constructors
@@ -51,7 +53,7 @@ namespace chip{
                     void stop();
                     double duration(); 
 
-                    double static duration_calc(timeval start, timeval stop) ;
+                    double static duration_calc(uint64_t start, uint64_t stop) ;
         };
 
     }


### PR DESCRIPTION
This implements duration timing of the commissioning processes for the purpose of comparing different devices performance. The timer/stopwatch can be extended for other purposes.

